### PR TITLE
Fixed unit test, which failed due to a duplicate link

### DIFF
--- a/appdeftransf_test.go
+++ b/appdeftransf_test.go
@@ -25,7 +25,7 @@ func TestMigrateV1ToV2(t *testing.T) {
 								userconfig.DependencyConfig{
 									Name:  "component_name3",
 									Port:  generictypes.MustParseDockerPort("80/tcp"),
-									Alias: "myalias",
+									Alias: "myalias3",
 								},
 								userconfig.DependencyConfig{
 									Name:  "component_name",


### PR DESCRIPTION
The unit tests where broken in master due to a better validation of duplicate links in user-config.